### PR TITLE
fix(android): transition issue with RNScreens

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ yarn add @danielsaraldi/react-native-blur-view
 Install native dependencies (**iOS only**):
 
 ```sh
-cd ios && pod install
+cd ios && pod install && cd ..
 ```
 
 ## Usage
@@ -129,7 +129,7 @@ An important detail, when a value less than `0` or greater than `100` are provid
 
 ### Android
 
-On Android platforms, the component utilizes the BlurView library to offer native blur effects with hardware-accelerated rendering.
+On Android platforms, the component utilizes the BlurView library to offer native blur effects with hardware-accelerated rendering. Support the animation transitions with [react-native-screens](https://github.com/software-mansion/react-native-screens).
 
 ### iOS
 

--- a/android/src/main/java/com/blurview/BlurViewManager.kt
+++ b/android/src/main/java/com/blurview/BlurViewManager.kt
@@ -7,7 +7,6 @@ import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.BlurViewManagerInterface
 import com.facebook.react.viewmanagers.BlurViewManagerDelegate
-import eightbitlab.com.blurview.BlurView
 
 @ReactModule(name = BlurViewManager.NAME)
 class BlurViewManager : ViewGroupManager<BlurView>(),
@@ -23,7 +22,7 @@ class BlurViewManager : ViewGroupManager<BlurView>(),
   }
 
   public override fun createViewInstance(context: ThemedReactContext): BlurView {
-    return com.blurview.BlurView.createViewInstance(context)
+    return BlurView(context)
   }
 
   companion object {
@@ -33,13 +32,13 @@ class BlurViewManager : ViewGroupManager<BlurView>(),
   @Override
   @ReactProp(name = "overlayColor")
   override fun setOverlayColor(view: BlurView?, overlarColor: String?) {
-    com.blurview.BlurView.setOverlayColor(view, overlarColor ?: "light")
+    view?.setOverlayColor(overlarColor ?: "light")
   }
 
   @Override
   @ReactProp(name = "blurRadius", defaultFloat = 10f)
   override fun setBlurRadius(view: BlurView?, radius: Float) {
-    com.blurview.BlurView.setRadius(view, radius)
+    view?.setRadius(radius)
   }
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BlurView (0.6.7):
+  - BlurView (0.7.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1906,7 +1906,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BlurView: b3b56e814a4a764e15e9298b9bf9c8744964914d
+  BlurView: 4d9c96156d7a6cd0285847fe9843afcfae6d9015
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6

--- a/example/src/styles.ts
+++ b/example/src/styles.ts
@@ -54,23 +54,15 @@ export const styles = StyleSheet.create({
     height: 144,
 
     justifyContent: 'flex-end',
-    alignItems: 'flex-start',
 
     padding: 20,
   },
 
   topBlurViewContainer: {
-    flex: 1,
-
     flexDirection: 'row',
-
-    width: '100%',
-    height: '100%',
 
     justifyContent: 'space-between',
     alignItems: 'flex-end',
-
-    gap: 8,
   },
 
   bottomBlurView: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,7 @@
-import type { ForwardRefExoticComponent } from 'react';
-import type { ViewProps } from 'react-native';
+import type { ComponentType } from 'react';
 import { BlurView as BlurViewUntyped } from './components';
+import type { BlurViewProps } from './@types';
 
-export const BlurView = BlurViewUntyped as ForwardRefExoticComponent<
-  ViewProps & {
-    /**
-     * @description Set the color type of the overlay.
-     *
-     * @type {BlurViewType}
-     *
-     * @default 'light'
-     */
-    type?:
-      | 'x-light'
-      | 'light'
-      | 'dark'
-      | 'thin-material'
-      | 'thin-material-light'
-      | 'thin-material-dark'
-      | 'material'
-      | 'material-light'
-      | 'material-dark'
-      | 'chrome-material'
-      | 'chrome-material-light'
-      | 'chrome-material-dark'
-      | 'thick-material'
-      | 'thick-material-light'
-      | 'thick-material-dark'
-      | 'ultra-thin-material'
-      | 'ultra-thin-material-light'
-      | 'ultra-thin-material-dark'
-      | 'regular'
-      | 'prominent';
-
-    /**
-     * @description Set the blur radius. It accepts a number between `0` and
-     * `100`.
-     *
-     * @default 10
-     */
-    radius?: number;
-  }
->;
+export const BlurView = BlurViewUntyped as ComponentType<BlurViewProps>;
 
 export type { BlurViewProps, BlurViewType } from './@types';


### PR DESCRIPTION
# Summary

During animated transitions on Android using [React Native Screens](https://github.com/software-mansion/react-native-screens), when the transition ends, the previous screen flashes.

After a short conversation with @hirbod (Thank you for your help), I replicated the changes that the SWEs at @expo made to this library. The changes were:

1. Change in the implementation of `BlurView`, before it was a **static class**, now it is a class that **inherits** the properties of the `BlurView` library.
2. Replicated the correct root view detection logic made by @expo.

### References

- https://github.com/software-mansion/react-native-screens/issues/3160
- https://github.com/expo/expo/pull/37904
