### PR TITLE
fix: adjust the type of the `reducedTransparencyFallbackColor` property

### DIFF
--- a/src/@types/BlurView.ts
+++ b/src/@types/BlurView.ts
@@ -44,7 +44,7 @@ export interface BlurViewProps extends ViewProps {
 
   /**
    * @description Set the downscale factor for the blur effect. It accepts a
-   * number between `0` and `15`. The higher the value, the more blurred the
+   * number between `0` and `100`. The higher the value, the more blurred the
    * effect will be, but it may also impact performance.
    *
    * @default 6
@@ -89,5 +89,5 @@ export interface BlurViewProps extends ViewProps {
    *
    * @since 1.4.0
    */
-  reducedTransparencyFallbackColor?: string;
+  reducedTransparencyFallbackColor?: ColorValue;
 }

--- a/src/@types/VibrancyView.ts
+++ b/src/@types/VibrancyView.ts
@@ -67,5 +67,5 @@ export interface VibrancyViewProps extends ViewProps {
    *
    * @since 1.4.0
    */
-  reducedTransparencyFallbackColor?: string;
+  reducedTransparencyFallbackColor?: ColorValue;
 }


### PR DESCRIPTION
## Summary 📋

> Brief description of what was done.

Fix the type of the `reducedTransparencyFallbackColor` property.

### React Native ⚛️

> Detailed checklist of each change on the React Native side (If necessary).

- [x] Fix `downscaleFactor` JSDoc.
- [x] Add the correct type in the `reducedTransparencyFallbackColor` property.

### Android 🤖

> Detailed checklist of each change on the Android side (If necessary).

--

### iOS 🍎

> Detailed checklist of each change on the iOS side (If necessary).

--

### References 💬

> Materials, links, and other resources used as references in the development process (If necessary).

--

