### PR TITLE
fix(android): gestures being cancelled under a `BlurTarget`

### DIFF
--- a/android/src/main/java/com/blurview/TargetView.kt
+++ b/android/src/main/java/com/blurview/TargetView.kt
@@ -95,7 +95,12 @@ class TargetView: ViewGroup {
 
   override fun getChildAt(index: Int): View? = blurTarget.getChildAt(index)
 
-  override fun indexOfChild(child: View?): Int = blurTarget.indexOfChild(child)
+  override fun indexOfChild(child: View?): Int {
+    if (child === blurTarget) {
+      return super.indexOfChild(child)
+    }
+    return blurTarget.indexOfChild(child)
+  }
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     val width = MeasureSpec.getSize(widthMeasureSpec)


### PR DESCRIPTION
## Summary 📋

> Brief description of what was done.

- https://github.com/expo/expo/pull/47404

### React Native ⚛️

> Detailed checklist of each change on the React Native side (If necessary).

--

### Android 🤖

> Detailed checklist of each change on the Android side (If necessary).

- [x] Fix gestures being cancelled under a `BlurTarget` component.

### iOS 🍎

> Detailed checklist of each change on the iOS side (If necessary).

--

### References 💬

> Materials, links, and other resources used as references in the development process (If necessary).

- https://github.com/expo/expo/pull/47404
- https://github.com/expo/expo/issues/47402
- https://github.com/software-mansion/react-native-gesture-handler/pull/4177

